### PR TITLE
Go: allow GET /api/v1/users to anyone via CORS

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/alioygur/gores v1.2.1
 	github.com/cristalhq/jwt/v3 v3.0.4
 	github.com/go-chi/chi v4.1.2+incompatible
+	github.com/go-chi/cors v1.1.1
 	github.com/google/uuid v1.1.2
 	github.com/matryer/is v1.4.0
 	go.etcd.io/bbolt v1.3.5

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/cristalhq/jwt/v3 v3.0.4 h1:1x04GZr04SJ3vd1Fsbl9eCPAuLwl753P7ywWgISrnd
 github.com/cristalhq/jwt/v3 v3.0.4/go.mod h1:XOnIXst8ozq/esy5N1XOlSyQqBd+84fxJ99FK+1jgL8=
 github.com/go-chi/chi v4.1.2+incompatible h1:fGFk2Gmi/YKXk0OmGfBh0WgmN3XB8lVnEyNz34tQRec=
 github.com/go-chi/chi v4.1.2+incompatible/go.mod h1:eB3wogJHnLi3x/kFX2A+IbTBlXxmMeXJVKy9tTv1XzQ=
+github.com/go-chi/cors v1.1.1 h1:eHuqxsIw89iXcWnWUN8R72JMibABJTN/4IOYI5WERvw=
+github.com/go-chi/cors v1.1.1/go.mod h1:K2Yje0VW/SJzxiyMYu6iPQYa7hMjQX2i/F491VChg1I=
 github.com/google/uuid v1.1.2 h1:EVhdT+1Kseyi1/pUmXKaFxYsDNy9RQYkMWRH68J/W7Y=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/matryer/is v1.4.0 h1:sosSmIWwkYITGrxZ25ULNDeKiMNzFSr4V/eqBQP0PeE=


### PR DESCRIPTION
This pulls in github.com/go-chi/cors, a middleware to manage CORS in
go-chi, and uses it to allow GET to /api/v1/users (and only that
endpoint) to anyone.

This is slightly awkward, as it seems like that library wasn't really
made to set up handler-specific CORS settings, only global. As such, we
have to manually specify an r.Options handler, that is the cors
middleware wrapping a nil handler.

Tested manually by doing:

    $ curl -H "Origin: http://example.com" \
        -H "Access-Control-Request-Method: GET" \
        -X OPTIONS --verbose \
        127.0.0.1:3000/api/v1/users
    [...]
    Access-Control-Allow-Methods: GET
    Access-Control-Allow-Origin: *

I can implement some unit/integration tests if someone would point me
into a recommended way of doing that within the go-chi ecosystem.

Replaces #30.