### PR TITLE
Go: Serve CORS on GET /api/v1/users

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -70,7 +70,7 @@ func main() {
 			// how go-chi/cors is supposed to be applied globally to the entire
 			// application, and not to particular endpoints.
 			r.With(publicCors.Handler).Options("/", nil)
-			r.Get("/", api.UsersAll(factoryStorage.Users()))
+			r.With(publicCors.Handler).Get("/", api.UsersAll(factoryStorage.Users()))
 			r.Post("/", api.UserCreate(factoryStorage.Users()))
 
 			r.With(lsmiddleware.UserID).Route("/{user-id}", func(r chi.Router) {


### PR DESCRIPTION
Tested with:

    $ curl -H "Origin: http://example.com" \
        -H "Access-Control-Request-Method: GET" \
        --verbose 127.0.0.1:3000/api/v1/users