### PR TITLE
Users can only delete themselves.

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -75,7 +75,12 @@ func main() {
 
 			r.With(lsmiddleware.UserID).Route("/{user-id}", func(r chi.Router) {
 				r.Get("/", api.UserRead(factoryStorage.Users()))
-				r.Delete("/", api.UserRemove(factoryStorage.Users()))
+
+				// Users can only delete themselves.
+				r.With(
+					lsmiddleware.ApiAuth(*config, false),
+					lsmiddleware.Private,
+				).Delete("/", api.UserRemove(factoryStorage.Users()))
 
 				r.With(
 					lsmiddleware.ApiAuth(*config, false),


### PR DESCRIPTION
Before that commit everyone could delete everyones account just by
checking user ids with `GET` request to `/api/v1/users`. After this
change you have to be logged in and you can only delete your account.

Right now basically single person can download everyones user data and
start maliciously deleting accounts without anyones knowledge.